### PR TITLE
Expose server lifecycle settings in config

### DIFF
--- a/api/src/main/kotlin/club/arson/impulse/api/config/LifecycleSettings.kt
+++ b/api/src/main/kotlin/club/arson/impulse/api/config/LifecycleSettings.kt
@@ -1,0 +1,70 @@
+/*
+ *  Impulse Server Manager for Velocity
+ *  Copyright (c) 2025  Dabb1e
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package club.arson.impulse.api.config
+
+import club.arson.impulse.api.config.ReconcileBehavior.FORCE
+import club.arson.impulse.api.config.ReconcileBehavior.ON_STOP
+import kotlinx.serialization.Serializable
+
+/**
+ * Lifecycle settings for a server
+ *
+ * These are settings that are used to control the basic lifecycle of a server. This allows a user to override the
+ * default behavior of the server manager.
+ * @property timeouts Various timeouts used for the server
+ * @property allowAutoStart Whether the server should be allowed to start automatically
+ * @property allowAutoStop Whether the server should be allowed to stop automatically
+ * @property shutdownBehavior The action to take when the server receives a shutdown signal. Either "STOP" or "REMOVE"
+ */
+@Serializable
+data class LifecycleSettings(
+    var timeouts: Timeouts = Timeouts(),
+    var allowAutoStart: Boolean = true,
+    var allowAutoStop: Boolean = true,
+    var reconciliationBehavior: ReconcileBehavior = ON_STOP,
+    var shutdownBehavior: ShutdownBehavior = ShutdownBehavior.STOP
+)
+
+/**
+ * Various timeouts used for the server
+ *
+ * @property startup The time in seconds before a server is considered to have failed to start
+ * @property shutdown The time in seconds before a server is considered to have failed to stop
+ * @property reconciliationGracePeriod The time in seconds to wait before reconciling servers if
+ *   [LifecycleSettings.reconciliationBehavior] is set to [ReconcileBehavior.FORCE]
+ * @property inactiveGracePeriod The time in seconds to wait before shutting down an inactive servers (no players)
+ */
+@Serializable
+data class Timeouts(
+    var startup: Long = 120,
+    var shutdown: Long = 120,
+    var reconciliationGracePeriod: Long = 60,
+    var inactiveGracePeriod: Long = 300,
+)
+
+/**
+ * The behavior to take when reconciling a server
+ * @property FORCE Reconcile the server immediately
+ * @property ON_STOP Reconcile the server on the next stop
+ */
+@Serializable
+enum class ReconcileBehavior {
+    FORCE,
+    ON_STOP
+}

--- a/api/src/main/kotlin/club/arson/impulse/api/config/Messages.kt
+++ b/api/src/main/kotlin/club/arson/impulse/api/config/Messages.kt
@@ -1,19 +1,19 @@
 /*
- * Impulse Server Manager for Velocity
- * Copyright (c) 2025  Dabb1e
+ *  Impulse Server Manager for Velocity
+ *  Copyright (c) 2025  Dabb1e
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package club.arson.impulse.api.config
@@ -34,5 +34,6 @@ import kotlinx.serialization.Serializable
 data class Messages(
     var startupError: String = "<red>Server is starting, please try again in a moment...</red>\nIf this issue persists, please contact an administrator",
     var reconcileRestartTitle: String = "<red>Server is Restarting...</red>",
-    var reconcileRestartMessage: String = "server restart imminent"
+    var reconcileRestartMessage: String = "server restart imminent",
+    var autoStartDisabled: String = "<red>Autostart is disabled for this server</red>"
 )

--- a/api/src/main/kotlin/club/arson/impulse/api/config/ServerConfig.kt
+++ b/api/src/main/kotlin/club/arson/impulse/api/config/ServerConfig.kt
@@ -1,19 +1,19 @@
 /*
- * Impulse Server Manager for Velocity
- * Copyright (c) 2025  Dabb1e
+ *  Impulse Server Manager for Velocity
+ *  Copyright (c) 2025  Dabb1e
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package club.arson.impulse.api.config
@@ -26,22 +26,13 @@ import kotlinx.serialization.Transient
  *
  * @property name The name of the server. Must match the server name in Velocity's configuration
  * @property type The type of server. Must be either "docker" or "kubernetes"
- * @property inactiveTimeout The time in seconds, after the last player leaves, before a server is considered inactive
- * @property startupTimeout The time in seconds before a server is considered to have failed to start
- * @property stopTimeout The time in seconds before a server is considered to have failed to stop
- * @property forceServerReconciliation Whether to force server reconciliation immediately or wait for the next restart
- * @property serverReconciliationGracePeriod The time in seconds to wait before reconciling servers if [forceServerReconciliation] is true
- * @property shutdownBehavior The action to take when the server receives a shutdown signal. Either "STOP" or "REMOVE"
+ * @property lifecycleSettings The lifecycle settings for the server
+ * @property config The broker specific configuration, this is not set directly, but rather injected by the config manager
  */
 @Serializable
 data class ServerConfig(
     var name: String,
     var type: String,
-    var inactiveTimeout: Long = 0,
-    var startupTimeout: Long = 120,
-    var stopTimeout: Long = 120,
-    var forceServerReconciliation: Boolean = false,
-    var serverReconciliationGracePeriod: Long = 60,
-    var shutdownBehavior: ShutdownBehavior = ShutdownBehavior.STOP,
+    var lifecycleSettings: LifecycleSettings = LifecycleSettings(),
     @Transient var config: Any? = null
 )

--- a/app/src/main/kotlin/club/arson/impulse/commands/ServerStatus.kt
+++ b/app/src/main/kotlin/club/arson/impulse/commands/ServerStatus.kt
@@ -49,10 +49,10 @@ fun getServerStatusMessage(name: String, status: Status, padTo: Int = 0): Compon
 fun serverStatusTable(servers: List<Server>): Component {
     val table = Component.text()
         .content("Server Status")
-    val maxLegtn = servers.maxOf { it.config.name.length }
+    val maxLength = servers.maxOf { it.config.name.length }
 
     servers.forEach { server ->
-        table.appendNewline().append(getServerStatusMessage(server.config.name, server.getStatus(), maxLegtn))
+        table.appendNewline().append(getServerStatusMessage(server.config.name, server.getStatus(), maxLength))
     }
 
     return table.build()

--- a/app/src/main/kotlin/club/arson/impulse/server/ServerBroker.kt
+++ b/app/src/main/kotlin/club/arson/impulse/server/ServerBroker.kt
@@ -26,7 +26,7 @@ import org.slf4j.Logger
 import kotlin.reflect.KClass
 
 /**
- * A class for managing server broker factories and configuration classes. Thes should be injected from the [BrokerModule].
+ * A class for managing server broker factories and configuration classes. These should be injected from the [club.arson.impulse.server.broker.BrokerModule].
  * Guice module.
  *
  * @property brokers a set of broker factories
@@ -34,7 +34,7 @@ import kotlin.reflect.KClass
  * @constructor creates a new server broker instance
  */
 class ServerBroker @Inject constructor(
-    protected val brokers: Set<BrokerFactory>,
+    private val brokers: Set<BrokerFactory>,
     val configClasses: Map<String, KClass<out Any>>
 ) {
     /**

--- a/app/src/main/kotlin/club/arson/impulse/server/ServerManager.kt
+++ b/app/src/main/kotlin/club/arson/impulse/server/ServerManager.kt
@@ -47,7 +47,7 @@ class ServerManager(private val proxy: ProxyServer, private val plugin: Impulse,
 
     private fun serverMaintenance() {
         servers.values.forEach { server ->
-            if (server.serverRef.playersConnected.isEmpty()) {
+            if (server.serverRef.playersConnected.isEmpty() && server.config.lifecycleSettings.allowAutoStop) {
                 logger?.trace("Found empty server ${server.serverRef.serverInfo.name}")
                 server.scheduleShutdown()
             }

--- a/docker-broker/src/main/kotlin/club/arson/impulse/dockerbroker/DockerBroker.kt
+++ b/docker-broker/src/main/kotlin/club/arson/impulse/dockerbroker/DockerBroker.kt
@@ -48,8 +48,8 @@ class DockerBroker(serverConfig: ServerConfig, private val logger: Logger? = nul
     private lateinit var dockerHost: String
 
     init {
-        startupTimeout = serverConfig.startupTimeout
-        stopTimeout = serverConfig.stopTimeout
+        startupTimeout = serverConfig.lifecycleSettings.timeouts.startup
+        stopTimeout = serverConfig.lifecycleSettings.timeouts.shutdown
         configureDockerClient(serverConfig)
     }
 
@@ -74,8 +74,8 @@ class DockerBroker(serverConfig: ServerConfig, private val logger: Logger? = nul
             .build()
 
         client = DockerClientImpl.getInstance(clientConfig, httpClient)
-        startupTimeout = config.startupTimeout
-        stopTimeout = config.stopTimeout
+        startupTimeout = config.lifecycleSettings.timeouts.startup
+        stopTimeout = config.lifecycleSettings.timeouts.shutdown
     }
 
     private fun createContainer(): Result<Unit> {
@@ -293,8 +293,8 @@ class DockerBroker(serverConfig: ServerConfig, private val logger: Logger? = nul
                     response = Result.success(Runnable {
                         removeServer()
                         configureDockerClient(config)
-                        stopTimeout = config.stopTimeout
-                        startupTimeout = config.startupTimeout
+                        stopTimeout = config.lifecycleSettings.timeouts.shutdown
+                        startupTimeout = config.lifecycleSettings.timeouts.startup
                         createContainer()
                         if (inspection.state.status == "running") {
                             startContainer()


### PR DESCRIPTION
Allow users more fine grained control over the server lifecycles by exposing config flags in the ServerConfig.
- Restructure ServerConfig to consolidate lifecycle settings
- Rename several settings
- Add allowAutoStop flag
- Add allowAutoStart flag
- Syntax cleanup
- Fix reconcile bug that would cause server settings to not update if no broker task was required

Fixes #8