### PR TITLE
Fix docker image auto pull logic

### DIFF
--- a/docker-broker/build.gradle.kts
+++ b/docker-broker/build.gradle.kts
@@ -31,6 +31,7 @@ dokka {
 dependencies {
     implementation("com.github.docker-java:docker-java-core:3.4.1")
     implementation("com.github.docker-java:docker-java-transport-httpclient5:3.4.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation(project(":impulse-api"))
 }
 
@@ -39,5 +40,6 @@ tasks {
         manifest {}
         from(sourceSets.main.get().output)
         relocate("com.github.docker-java", "club.arson.impulse.docker-java")
+        relocate("org.jetbrains.kotlinx", "club.arson.impulse.kotlinx")
     }
 }


### PR DESCRIPTION
Fixes for the docker image auto pull logic. These should make things more consistant
- Pull in async function
- Start pulls on server creation/reconciliation instead of player joins
- Add imagePullPolicy config option
- Change volumes def to be more like composer
- Fix autostart logic so it respects config option
- Add config option for container autostart on creation (default false)

Fixes #7