### PR TITLE
Add pin & unpin commands

### DIFF
--- a/app/src/main/kotlin/club/arson/impulse/commands/ImpulseCommand.kt
+++ b/app/src/main/kotlin/club/arson/impulse/commands/ImpulseCommand.kt
@@ -24,10 +24,15 @@ fun createImpulseCommand(): BrigadierCommand {
     val startNode = createStartServerCommand()
     val commandNode = BrigadierCommand.literalArgumentBuilder("impulse")
         .then(startNode)
-        .then(BrigadierCommand.literalArgumentBuilder("warm").redirect(startNode.build()))
+        .then(
+            BrigadierCommand.literalArgumentBuilder("warm")
+                .requires { source -> source.hasPermission("impulse.server.start") }
+                .redirect(startNode.build()))
         .then(createStopServerCommand())
         .then(createRemoveServerCommand())
         .then(createReconcileCommand())
         .then(createServerStatusCommand())
+        .then(createPinServerCommand())
+        .then(createUnpinServerCommand())
     return BrigadierCommand(commandNode)
 }

--- a/app/src/main/kotlin/club/arson/impulse/commands/PinServer.kt
+++ b/app/src/main/kotlin/club/arson/impulse/commands/PinServer.kt
@@ -1,0 +1,56 @@
+/*
+ *  Impulse Server Manager for Velocity
+ *  Copyright (c) 2025  Dabb1e
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package club.arson.impulse.commands
+
+import club.arson.impulse.ServiceRegistry
+import com.mojang.brigadier.Command
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.velocitypowered.api.command.CommandSource
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+fun createPinServerCommand(): LiteralArgumentBuilder<CommandSource> {
+    return createGenericServerCommand("pin") { context, serverName ->
+        val server = ServiceRegistry.instance.serverManager?.getServer(serverName)
+        if (server != null) {
+            server.pinned = true
+            context.source.sendMessage(
+                Component.text()
+                    .content("Server $serverName ")
+                    .append(
+                        Component.text("pinned")
+                            .color(NamedTextColor.RED)
+                    )
+            )
+        } else {
+            context.source.sendMessage(
+                Component.text()
+                    .append(
+                        Component.text("Error: ")
+                            .color(NamedTextColor.RED)
+                    )
+                    .append(
+                        Component.text("server $serverName not found")
+                    )
+
+            )
+        }
+        return@createGenericServerCommand Command.SINGLE_SUCCESS
+    }
+}

--- a/app/src/main/kotlin/club/arson/impulse/commands/UnpinServer.kt
+++ b/app/src/main/kotlin/club/arson/impulse/commands/UnpinServer.kt
@@ -1,0 +1,56 @@
+/*
+ *  Impulse Server Manager for Velocity
+ *  Copyright (c) 2025  Dabb1e
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package club.arson.impulse.commands
+
+import club.arson.impulse.ServiceRegistry
+import com.mojang.brigadier.Command
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.velocitypowered.api.command.CommandSource
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+fun createUnpinServerCommand(): LiteralArgumentBuilder<CommandSource> {
+    return createGenericServerCommand("unpin") { context, serverName ->
+        val server = ServiceRegistry.instance.serverManager?.getServer(serverName)
+        if (server != null) {
+            server.pinned = false
+            context.source.sendMessage(
+                Component.text()
+                    .content("Server $serverName ")
+                    .append(
+                        Component.text("unpinned")
+                            .color(NamedTextColor.GREEN)
+                    )
+            )
+        } else {
+            context.source.sendMessage(
+                Component.text()
+                    .append(
+                        Component.text("Error: ")
+                            .color(NamedTextColor.RED)
+                    )
+                    .append(
+                        Component.text("server $serverName not found")
+                    )
+
+            )
+        }
+        return@createGenericServerCommand Command.SINGLE_SUCCESS
+    }
+}

--- a/app/src/main/kotlin/club/arson/impulse/server/ServerManager.kt
+++ b/app/src/main/kotlin/club/arson/impulse/server/ServerManager.kt
@@ -52,7 +52,7 @@ class ServerManager @Inject constructor(
 
     private fun serverMaintenance() {
         servers.values.forEach { server ->
-            if (server.serverRef.playersConnected.isEmpty() && server.config.lifecycleSettings.allowAutoStop) {
+            if (server.serverRef.playersConnected.isEmpty() && server.config.lifecycleSettings.allowAutoStop && !server.pinned) {
                 logger?.trace("Found empty server ${server.serverRef.serverInfo.name}")
                 server.scheduleShutdown()
             }


### PR DESCRIPTION
Add commands to pin and unpin a server. Pinning will stop all auto shutdown features and preven shutdown with `/imp stop`. This is useful for event servers.
- Add Pin command to disable shutdown
- Add Unpin to revert to normal
- Fix security check for `/imp warm` command

Fixes #5