### PR TITLE
Add TLS support to docker broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sources:
 ## Documentation
 
 For more detailed information on how to use Impulse, see our [documentation](https://arson-club.github.io/Impulse/).
-For API documentation, see out [KDocs](https://arson-club.github.io/Impulse/kdocs/index.html).
+For API documentation, see our [KDocs](https://arson-club.github.io/Impulse/kdocs/index.html).
 
 ## Quick Start
 

--- a/docker-broker/build.gradle.kts
+++ b/docker-broker/build.gradle.kts
@@ -29,7 +29,7 @@ dokka {
 }
 
 dependencies {
-    implementation("com.github.docker-java:docker-java-core:3.4.1")
+    implementation("com.github.docker-java:docker-java:3.4.1")
     implementation("com.github.docker-java:docker-java-transport-httpclient5:3.4.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation(project(":api"))

--- a/docker-broker/src/main/kotlin/club/arson/impulse/dockerbroker/DockerServerConfig.kt
+++ b/docker-broker/src/main/kotlin/club/arson/impulse/dockerbroker/DockerServerConfig.kt
@@ -47,8 +47,27 @@ data class DockerServerConfig(
     var autoStartOnCreate: Boolean = false,
     var portBindings: List<String> = listOf("25565:25565"),
     var hostPath: String = "unix:///var/run/docker.sock",
+    var tlsConfig: DockerTlsConfig = DockerTlsConfig(),
     var volumes: List<String> = emptyList(),
     var env: Map<String, String> = mapOf("ONLINE_MODE" to "false"),
+)
+
+/**
+ * TLS configuration for the Docker connection
+ *
+ * @property enabled Whether TLS is enabled or not
+ * @property tlsVerify Whether to verify the server's certificate
+ * @property clientKeyPassword Password for the client key (if different from the keystore password)
+ * @property keystorePath Path to the java PKCS12 keystore holding the client key, client cert, and CA cert
+ * @property keystorePassword Password for the keystore
+ */
+@Serializable
+data class DockerTlsConfig(
+    var enabled: Boolean = false,
+    var tlsVerify: Boolean = true,
+    var clientKeyPassword: String? = null,
+    var keystorePath: String? = null,
+    var keystorePassword: String? = null
 )
 
 /**

--- a/docs/getting_started/prerequisites.md
+++ b/docs/getting_started/prerequisites.md
@@ -18,12 +18,11 @@ on which broker you choose, you may need to install additional software on your 
 
 ### Docker
 
-Currently Docker is the only broker implementation available. Any machine that you would like Impulse to manage backend
-servers must have docker installed. You can follow
-the [official docker installation guide](https://docs.docker.com/get-docker/) to install docker on your machine.
+Currently Docker is the only broker implementation available. Any computer you would like Impulse to run servers on via this
+broker must have docker installed. You can follow the
+[official docker installation guide](https://docs.docker.com/get-docker/).
 
-In this example, we will running our backend servers on the same machine as our proxy. If you run your proxy on a
-separate machine, docker is not required for that computer.
+In this example, are running our backend servers on the same machine as our proxy.
 
 > [!TIP]
 > For more information on the docker broker itself, see

--- a/docs/getting_started/velocity_configuration.md
+++ b/docs/getting_started/velocity_configuration.md
@@ -1,31 +1,42 @@
 # Velocity Configuration
+
 Velocity's configuration is stored in the `velocity.toml` file. For more information on all the available options, see
 [Velocity's configuration documentation](https://docs.papermc.io/velocity/configuration).
 
 For this guide we will only need to touch a few options.
 
 ## Servers
-Due to some current limitations, you will still need to define your servers in the `velocity.toml` file. This can be done
-as normal. For our simple SMP server, we can use the following configuration:
+
+Due to some limitations in the Velocity API, you need to define any server you would like to directly connect to through
+either the `try` or `forced-hoses` blocks in the `velocity.toml` file. We are going to add the connection information
+for our SMP server since we want all players to connect to it by default. We will later configure Impulse to adopt the
+server reference that velocity creates here.
+
 ```toml
 [servers]
 smp = "127.0.0.1:25566"
 ```
+
 > [!IMPORTANT]
 > Make a note of the server "name" used here. We will need it later.
 
 ## Try
-For our use case, we want to set up our smp server as the default server for Velocity.
+
+The easiest way to get all our players to connect to our SMP by default is to set it as the first (and only) option in
+the `try` block. Impulse is not affected by this or the `forced-hosts` settings.
+
 ```toml
 try = ["smp"]
 ```
 
 ## Player Info Forwarding
+
 Since we are running Velocity in online mode, we can set up player info forwarding to our SMP server so that people get
 their skins and correct usernames. Simply change the following option:
+
 ```toml
 player-info-forwarding = "modern"
 ```
 
-That is it for the Velocity configuration! Save the file and either reload it with `/velocity reload` or restart the proxy.
-
+That is it for the Velocity configuration! Save the file and either reload it with `/velocity reload` or restart the
+proxy.

--- a/docs/reference/brokers.md
+++ b/docs/reference/brokers.md
@@ -9,8 +9,7 @@ not include any brokers.
 
 Impulse is capable of dynamically loading additional brokers at startup. To add a broker, place the jar in
 Impulse's data directory (normally `plugins/impulse`). Hot reloading is not currently supported. You will need to
-restart
-Velocity to update add a new broker or update an existing one.
+restart Velocity to update add a new broker or update an existing one.
 
 ## First Party Brokers
 

--- a/docs/reference/docker-broker.md
+++ b/docs/reference/docker-broker.md
@@ -22,8 +22,19 @@ Docker broker specific configuration values. These should be nested under the `d
 | `autoStartOnCreate` | `boolean`      | Controls autostart behaviour for the container. If set to true we will start the container at creation time, not when a user connects.                                                           | `false`                       |
 | `portBindings`      | `list<string>` | List of port bindings to use for the server. Each entry should be a string in the format `hostPort:containerPort`                                                                                | `["25565:25565"]`             |
 | `hostPath`          | `string`       | URI to the docker daemon location. This can either be a local socket, or a remote host.                                                                                                          | `unix:///var/run/docker.sock` |
+| `tlsConfig`         | `object`       | TLS related configuration options if connecting to the docker daemon over TCP                                                                                                                    |                               |
 | `volumes`           | `list<string>` | List of host directories to mount into the container. These should be strings in the format `/host/path:/container/path`                                                                         | `{}`                          |
 | `env`               | `Map`          | Map of environment variables to pass to the container. The key is the variable name, and the value is the variable value.                                                                        | `{"ONLINE_MODE": "false"}`    |
+
+### TLS Configuration
+
+| Key                 | Type      | Description                                                                            | Default |
+|---------------------|-----------|----------------------------------------------------------------------------------------|---------|
+| `enabled`           | `boolean` | Should we enable TLS for this docker connection                                        | `false` |
+| `tlsVerify`         | `boolean` | Should we verify the host certificate for this connection                              | `true`  |
+| `clientKeyPassword` | `string`  | Password for the client key if it differs from the `keystorePassowrd`                  | `null`  |
+| `keystorePath`      | `string`  | Java PKCS12 formatted keystore that contains your client cert, client key, and CA cert | `null`  |
+| `keystorePassword`  | `string`  | Password for accessing the configured keystore                                         | `null`  |
 
 ### Image Pull Policy
 
@@ -40,6 +51,40 @@ Most changes under the `docker` configuration key will require a server recreati
 will automatically stop, remove, and recreate the server container as needed. Because of this behavior, it is important
 to make sure any data you want to keep is stored in a volume. If not it will be lost during a reconciliation event. This
 can normally be accomplished by mounting a volume to the `/data` directory in the container.
+
+## Using TLS
+
+Docker uses TLS to secure connections the the daemon over TCP. If you are using a remote docker daemon, it is highly
+encouraged to use TLS to secure the connection. The following instuctions will go over how to generate the keystore for
+Impulse from your PKI. To set up the certificates and keys in the first place
+follow [docker's guide](https://docs.docker.com/engine/security/protect-access/)
+
+### Generating the Keystore
+
+First, If you need to convert your client credentials to PKCS12 format you can use the following command. Replace
+`<your_keystore_password>` with a real password.
+
+```shell
+openssl pkcs12 -export -in client.crt -inkey client.key \
+-out client-keystore.p12 -name client-cert -passout pass:<your_keystore_password>
+````
+
+Next generate the keystore by importing the client certificate and key.
+
+```shell
+keytool -importkeystore -srckeystore docker-keystore.p12 -srcstoretype PKCS12 \
+-srcstorepass <your_keystore_password> -destkeystore docker-keystore.p12 -deststoretype PKCS12 \
+-deststorepass <your_keystore_password>
+```
+
+Lastly, inject the CA certificate into the keystore.
+
+```shell
+keytool -importcert -alias ca-cert -file ca.crt \
+-keystore docker-keystore.p12 -storepass your_keystore_password -noprompt
+````
+
+Your keystore should now be set up and ready to use with Impulse.
 
 ## Example Configuration
 


### PR DESCRIPTION
Support tls connections to remote docker daemons. This enables secure creation of servers on remote machines with the docker broker.