### PR TITLE
Update error handling for configuration init

### DIFF
--- a/app/src/test/kotlin/club/arson/impulse/ConfigManagerTest.kt
+++ b/app/src/test/kotlin/club/arson/impulse/ConfigManagerTest.kt
@@ -18,27 +18,206 @@
 
 package club.arson.impulse
 
+import club.arson.impulse.api.config.Configuration
+import club.arson.impulse.api.events.ConfigReloadEvent
 import club.arson.impulse.config.ConfigManager
 import club.arson.impulse.inject.modules.BaseModule
-import club.arson.impulse.inject.modules.BrokerModule
+import com.google.inject.AbstractModule
 import com.google.inject.Guice
-import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.BeforeEach
+import com.velocitypowered.api.event.EventManager
+import com.velocitypowered.api.event.ResultedEvent.GenericResult
+import com.velocitypowered.api.proxy.ProxyServer
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.slf4j.Logger
+import java.io.File
+import java.io.IOException
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import kotlin.io.path.createDirectories
+import kotlin.io.path.inputStream
+import kotlin.test.assertEquals
+
+class ConfigManagerTestModule(val reloadOnInit: Boolean) : AbstractModule() {
+    override fun configure() {
+        bind(Boolean::class.java).toInstance(reloadOnInit)
+    }
+}
 
 class ConfigManagerTest {
-    val configPath: Path = mockk()
-    val injector = Guice.createInjector(BaseModule(mockk(), mockk(), configPath, mockk()), BrokerModule())
-    val configFile: Path = mockk()
-    lateinit var configManager: ConfigManager
-
-    @BeforeEach
-    fun setup() {
-        every { configPath.resolve("config.yaml") } returns configFile
-        configManager = injector.getInstance(ConfigManager::class.java)
-
+    private fun getConfigManager(
+        proxy: ProxyServer = mockk(relaxed = true),
+        plugin: Impulse = mockk(relaxed = true),
+        configPath: Path = mockk(relaxed = true),
+        reloadOnInit: Boolean = false,
+        logger: Logger = mockk(relaxed = true)
+    ): ConfigManager {
+        val injector =
+            Guice.createInjector(BaseModule(plugin, proxy, configPath, logger), ConfigManagerTestModule(reloadOnInit))
+        return injector.getInstance(ConfigManager::class.java)
     }
 
+    @Test
+    fun testConfigManagerCreateDirectorySuccess() {
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { toFile().exists() } returns false
+        }
+        assertDoesNotThrow { getConfigManager(configPath = configPath) }
+        verify(exactly = 1) { configPath.toFile().exists() }
+        verify(exactly = 1) { configPath.createDirectories() }
+    }
 
+    @Test
+    fun testConfigManagerCreateConfigFileSuccess() {
+        mockkStatic(File::writeText)
+
+        val configToFile = mockk<File>(relaxed = true).apply {
+            every { exists() } returns false
+            every { writeText(any()) } returns Unit
+        }
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { toFile() } returns configToFile
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { toFile().exists() } returns true
+            every { resolve(any<String>()) } returns configFile
+        }
+
+        assertDoesNotThrow { getConfigManager(configPath = configPath) }
+        verify(exactly = 1) { configPath.toFile().exists() }
+        verify(exactly = 0) { configPath.createDirectories() }
+        verify(exactly = 1) { configToFile.writeText(any()) }
+    }
+
+    @Test
+    fun testConfigManagerCreateConfigFileFailure() {
+        mockkStatic(File::writeText)
+
+        val configToFile = mockk<File>(relaxed = true).apply {
+            every { exists() } returns false
+            every { writeText(any()) } throws IOException("Test")
+        }
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { toFile() } returns configToFile
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { toFile().exists() } returns true
+            every { resolve(any<String>()) } returns configFile
+        }
+
+        assertDoesNotThrow { getConfigManager(configPath = configPath) }
+        verify(exactly = 1) { configPath.toFile().exists() }
+        verify(exactly = 0) { configPath.createDirectories() }
+        verify(exactly = 1) { configToFile.writeText(any()) }
+    }
+
+    @Test
+    fun testConfigManagerWatcherFails() {
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { register(any(), *anyVararg()) } throws Exception("Test")
+        }
+        val logger = mockk<Logger>(relaxed = true)
+        assertDoesNotThrow { getConfigManager(configPath = configPath, logger = logger) }
+        verify { logger.error(any()) }
+    }
+
+    @Test
+    fun testConfigManagerEmptyConfig() {
+        val config = ""
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { inputStream() } returns config.byteInputStream()
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { resolve(any<String>()) } returns configFile
+        }
+        val generatedEvent = slot<ConfigReloadEvent>()
+        val proxy = mockk<ProxyServer>(relaxed = true).apply {
+            every { eventManager } returns mockk<EventManager>(relaxed = true).apply {
+                every { fire(capture(generatedEvent)) } answers { CompletableFuture.completedFuture(generatedEvent.captured) }
+            }
+        }
+        assertDoesNotThrow { getConfigManager(proxy = proxy, configPath = configPath, reloadOnInit = true) }
+        assertEquals(GenericResult.allowed(), generatedEvent.captured.result)
+    }
+
+    @Test
+    fun testConfigManagerMissingConfig() {
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { inputStream() } throws IOException("Test")
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { resolve(any<String>()) } returns configFile
+        }
+        val generatedEvent = slot<ConfigReloadEvent>()
+        val proxy = mockk<ProxyServer>(relaxed = true).apply {
+            every { eventManager } returns mockk<EventManager>(relaxed = true).apply {
+                every { fire(capture(generatedEvent)) } answers { CompletableFuture.completedFuture(generatedEvent.captured) }
+            }
+        }
+        assertDoesNotThrow { getConfigManager(proxy = proxy, configPath = configPath, reloadOnInit = true) }
+        assertEquals(GenericResult.allowed(), generatedEvent.captured.result)
+    }
+
+    @Test
+    fun testConfigManagerUnknownReadError() {
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { inputStream() } throws Exception("Test")
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { resolve(any<String>()) } returns configFile
+        }
+        val generatedEvent = slot<ConfigReloadEvent>()
+        val proxy = mockk<ProxyServer>(relaxed = true).apply {
+            every { eventManager } returns mockk<EventManager>(relaxed = true).apply {
+                every { fire(capture(generatedEvent)) } answers { CompletableFuture.completedFuture(generatedEvent.captured) }
+            }
+        }
+        assertDoesNotThrow { getConfigManager(proxy = proxy, configPath = configPath, reloadOnInit = true) }
+        assertEquals(GenericResult.denied(), generatedEvent.captured.result)
+    }
+
+    @Test
+    fun testConfigManagerMinimalConfig() {
+        val configYaml = """
+            instanceName: Test
+        """.trimIndent()
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { inputStream() } returns configYaml.byteInputStream()
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { resolve(any<String>()) } returns configFile
+        }
+        val generatedEvent = slot<ConfigReloadEvent>()
+        val proxy = mockk<ProxyServer>(relaxed = true).apply {
+            every { eventManager } returns mockk<EventManager>(relaxed = true).apply {
+                every { fire(capture(generatedEvent)) } answers { CompletableFuture.completedFuture(generatedEvent.captured) }
+            }
+        }
+        val configManager = getConfigManager(proxy = proxy, configPath = configPath, reloadOnInit = true)
+        assertEquals(GenericResult.allowed(), generatedEvent.captured.result)
+        assertEquals("Test", configManager.instanceName)
+    }
+
+    @Test
+    fun testConfigManagerMinimalConfigFailuer() {
+        val configYaml = """
+            badKey: Test
+        """.trimIndent()
+        val configFile = mockk<Path>(relaxed = true).apply {
+            every { inputStream() } returns configYaml.byteInputStream()
+        }
+        val configPath = mockk<Path>(relaxed = true).apply {
+            every { resolve(any<String>()) } returns configFile
+        }
+        val generatedEvent = slot<ConfigReloadEvent>()
+        val proxy = mockk<ProxyServer>(relaxed = true).apply {
+            every { eventManager } returns mockk<EventManager>(relaxed = true).apply {
+                every { fire(capture(generatedEvent)) } answers { CompletableFuture.completedFuture(generatedEvent.captured) }
+            }
+        }
+        val configManager = getConfigManager(proxy = proxy, configPath = configPath, reloadOnInit = true)
+        assertEquals(GenericResult.denied(), generatedEvent.captured.result)
+        assertEquals(Configuration().instanceName, configManager.instanceName) // assert default value
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
-version=0.2.1
+version=0.3.0-SNAPSHOT
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true


### PR DESCRIPTION
Fix error handling to make the config bringup more reliable.
- Create defaul configuration file if none is present
- Warn user if unable to create default config
- Make IOException while trying to read the config file non-error (handle the same as an empty config)
- Warn user with instructions if config file is unreadable or empty
- Make Empty or missing config dispatch regular config event with default values (no more confusing "using old config" message)

Fixes #37