### PR TITLE
Fix Velocity 4 injection and add backend startup notifications

### DIFF
--- a/app/src/main/kotlin/club/arson/impulse/PlayerLifecycleListener.kt
+++ b/app/src/main/kotlin/club/arson/impulse/PlayerLifecycleListener.kt
@@ -1,13 +1,21 @@
 /*
  *  Impulse Server Manager for Velocity
  *  Copyright (c) 2025 Dabb1e
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
  *
- *  Drop-in replacement preserving the original listener behavior while adding
- *  title notifications during managed server startup and transfer.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.*
  */
 
 package club.arson.impulse
-
 import com.google.inject.Inject
 import com.velocitypowered.api.event.EventTask
 import com.velocitypowered.api.event.PostOrder

--- a/app/src/main/kotlin/club/arson/impulse/PlayerLifecycleListener.kt
+++ b/app/src/main/kotlin/club/arson/impulse/PlayerLifecycleListener.kt
@@ -1,23 +1,14 @@
 /*
  *  Impulse Server Manager for Velocity
- *  Copyright (c) 2025  Dabb1e
+ *  Copyright (c) 2025 Dabb1e
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Affero General Public License for more details.
- *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *  Drop-in replacement preserving the original listener behavior while adding
+ *  title notifications during managed server startup and transfer.
  */
 
 package club.arson.impulse
 
+import com.google.inject.Inject
 import com.velocitypowered.api.event.EventTask
 import com.velocitypowered.api.event.PostOrder
 import com.velocitypowered.api.event.Subscribe
@@ -28,25 +19,68 @@ import com.velocitypowered.api.proxy.Player
 import com.velocitypowered.api.proxy.server.RegisteredServer
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.title.Title
 import org.slf4j.Logger
-import javax.inject.Inject
+import java.time.Duration
 
 /**
- * Listens for player lifecycle events and processes them
- *
- * Listens for connect and disconnect events so that we can start and stop servers
- * @param logger the logger to write messages to
- * @constructor creates a new PlayerLifecycleListener registered with an optional logger.
+ * Listens for connect and disconnect events so managed servers can be started
+ * before transfer and stopped after becoming empty.
  */
-class PlayerLifecycleListener @Inject constructor(private val logger: Logger) {
+class PlayerLifecycleListener @Inject constructor(
+    private val logger: Logger
+) {
+    private val miniMessage = MiniMessage.miniMessage()
+
     private fun getMM(message: String?): Component {
-        return MiniMessage
-            .miniMessage()
-            .deserialize(message ?: "<red>Unknown error</red>")
+        return miniMessage.deserialize(message ?: "<red>Unknown error</red>")
+    }
+
+    private fun showStartingTitle(player: Player, serverName: String) {
+        player.showTitle(
+            Title.title(
+                getMM("<gold>Starting $serverName</gold>"),
+                getMM("<gray>Please wait while the server comes online...</gray>"),
+                Title.Times.times(
+                    Duration.ofMillis(500),
+                    Duration.ofSeconds(10),
+                    Duration.ofMillis(1000)
+                )
+            )
+        )
+    }
+
+    private fun showTransferTitle(player: Player, serverName: String) {
+        player.showTitle(
+            Title.title(
+                getMM("<green>Server Ready</green>"),
+                getMM("<gray>Transferring to $serverName...</gray>"),
+                Title.Times.times(
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2),
+                    Duration.ofMillis(300)
+                )
+            )
+        )
+    }
+
+    private fun showFailureTitle(player: Player, serverName: String) {
+        player.showTitle(
+            Title.title(
+                getMM("<red>Server Unavailable</red>"),
+                getMM("<gray>Unable to connect to $serverName.</gray>"),
+                Title.Times.times(
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(3),
+                    Duration.ofMillis(400)
+                )
+            )
+        )
     }
 
     /**
-     * Either drops the player or sends a message depending on if they are transferring or not
+     * Either lets Velocity continue its initial try list or denies a transfer
+     * and sends the configured message to the player.
      */
     private fun handleTimeout(
         player: Player,
@@ -54,8 +88,9 @@ class PlayerLifecycleListener @Inject constructor(private val logger: Logger) {
         message: String? = null
     ): ServerResult {
         if (previousServer == null) {
-            // This is a workaround so that velocity will continue to hunt the try list
-            throw IllegalStateException("Server hit timeout while starting: ${message ?: "Unknown error"}")
+            throw IllegalStateException(
+                "Server hit timeout while starting: ${message ?: "Unknown error"}"
+            )
         } else {
             player.sendMessage(getMM(message))
         }
@@ -63,31 +98,48 @@ class PlayerLifecycleListener @Inject constructor(private val logger: Logger) {
         return ServerResult.denied()
     }
 
+    /**
+     * Processes a connection attempt to a managed server.
+     *
+     * This remains public because the existing unit tests invoke it directly.
+     */
     fun handlePlayerConnectEvent(event: ServerPreConnectEvent) {
-        val server = ServiceRegistry.instance.serverManager?.getServer(event.originalServer.serverInfo.name)
+        val serverName = event.originalServer.serverInfo.name
+        val server = ServiceRegistry.instance.serverManager?.getServer(serverName)
+
         if (server != null) {
-            val prevServer =
-                if (event.previousServer != null) ServiceRegistry.instance.serverManager?.getServer(event.previousServer!!.serverInfo.name) else null
+            val previousManagedServer =
+                if (event.previousServer != null) {
+                    ServiceRegistry.instance.serverManager
+                        ?.getServer(event.previousServer!!.serverInfo.name)
+                } else {
+                    null
+                }
+
             var isRunning = server.isRunning()
 
-            // if the server is not running and auto start is enabled, start the server
             if (!isRunning && server.config.lifecycleSettings.allowAutoStart) {
+                showStartingTitle(event.player, serverName)
+
                 server.startServer().onSuccess {
                     logger.debug("Server started successfully, allowing connection")
                     isRunning = true
                 }.onFailure {
                     logger.warn("Error: failed to start server, rejecting connection")
                     logger.warn(it.message)
+                    showFailureTitle(event.player, serverName)
                 }
             }
 
-            // If we are started, await ready and transfer the player
             if (isRunning) {
                 server.awaitReady().onSuccess {
                     logger.trace("Server reporting ready, transferring player")
-                    prevServer?.handleDisconnect(event.player.username)
+                    showTransferTitle(event.player, serverName)
+                    previousManagedServer?.handleDisconnect(event.player.username)
                 }.onFailure {
                     logger.debug("Server failed to report ready, rejecting connection")
+                    showFailureTitle(event.player, serverName)
+
                     event.result = handleTimeout(
                         event.player,
                         event.previousServer,
@@ -95,14 +147,12 @@ class PlayerLifecycleListener @Inject constructor(private val logger: Logger) {
                     )
                 }
             } else if (!server.config.lifecycleSettings.allowAutoStart) {
-                // If we are not started and auto start is disabled, reject the connection with the correct message
                 event.result = handleTimeout(
                     event.player,
                     event.previousServer,
                     ServiceRegistry.instance.configManager?.messages?.autoStartDisabled
                 )
             } else {
-                // Otherwise reject with an unknown error
                 event.result = handleTimeout(
                     event.player,
                     event.previousServer,
@@ -115,37 +165,36 @@ class PlayerLifecycleListener @Inject constructor(private val logger: Logger) {
     }
 
     /**
-     * Handles the ServerPreConnectEvent
-     *
-     * This event is fired when a player is about to connect to a server. We use this event to start the server if it is not already running.
-     * @param event the ServerPreConnectEvent
-     * @return an EventTask that will start the server if it is not already running
-     * @see [ServerPreConnectEvent](https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/player/ServerPreConnectEvent.html)
+     * Starts a managed destination server before Velocity completes transfer.
      */
     @Subscribe(order = PostOrder.FIRST)
     fun onServerPreConnectEvent(event: ServerPreConnectEvent): EventTask {
-        logger.debug("Handling ServerPreConnectEvent for ${event.player.username} from ${event.previousServer?.serverInfo?.name ?: "No Previous Server"} to ${event.originalServer.serverInfo.name}")
+        logger.debug(
+            "Handling ServerPreConnectEvent for ${event.player.username} " +
+                "from ${event.previousServer?.serverInfo?.name ?: "No Previous Server"} " +
+                "to ${event.originalServer.serverInfo.name}"
+        )
+
         return EventTask.async {
             handlePlayerConnectEvent(event)
         }
     }
 
     /**
-     * Handles the DisconnectEvent
-     *
-     * This is fired when a player disconnects from the server. We will use this to schedule a shutdown if the server is empty.
-     * @param event the DisconnectEvent
-     * @see [DisconnectEvent](https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/connection/DisconnectEvent.html)
+     * Schedules shutdown when the final player leaves a managed server.
      */
     @Subscribe(order = PostOrder.LAST)
     fun onDisconnectEvent(event: DisconnectEvent) {
         runCatching {
             event.player.currentServer.get().server
         }.onSuccess {
-            ServiceRegistry.instance.serverManager?.getServer(it.serverInfo.name)
+            ServiceRegistry.instance.serverManager
+                ?.getServer(it.serverInfo.name)
                 ?.handleDisconnect(event.player.username)
         }.onFailure {
-            logger.debug("unable to determine tha disconnect server for ${event.player.username}")
+            logger.debug(
+                "unable to determine tha disconnect server for ${event.player.username}"
+            )
         }
     }
 }


### PR DESCRIPTION
## AI assistance disclosure

Codex was used to assist with diagnosing the Velocity 4 compatibility issue, preparing the code changes, and refining the implementation. The resulting changes were reviewed, tested, and validated by the contributor before submission.

## Summary

This change fixes `PlayerLifecycleListener` initialization under Velocity 4 and adds player-facing title notifications while managed backend servers start.

## Changes

- Replace `javax.inject.Inject` with `com.google.inject.Inject`
- Show a title while an offline managed server is starting
- Show a title when the server is ready and transfer is beginning
- Show a failure title if startup or readiness checks fail
- Preserve existing connection, timeout, fallback, and shutdown behavior
- Preserve the existing unit-test expectations by using titles rather than additional chat messages

## Root cause

Under Velocity 4, Guice did not recognize the listener constructor annotated with `javax.inject.Inject`, causing Impulse initialization to fail with:

```text
[Guice/MissingConstructor]: No injectable constructor for type PlayerLifecycleListener
